### PR TITLE
Remove Volley module and fix API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,5 @@ gradle-app.setting
 
 ### Google
 /app/google-services.json
+
+.DS_Store

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding">
-    <file url="PROJECT" charset="UTF-8" />
-  </component>
-</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,10 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/DixitApp.iml" filepath="$PROJECT_DIR$/DixitApp.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
       <module fileurl="file://$PROJECT_DIR$/dixit.iml" filepath="$PROJECT_DIR$/dixit.iml" />
-      <module fileurl="file://$PROJECT_DIR$/volley/volley.iml" filepath="$PROJECT_DIR$/volley/volley.iml" />
     </modules>
   </component>
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,6 +18,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    buildTypes.each{
+        it.buildConfigField 'String', 'GOOGLE_NLP_API_KEY', GOOGLE_NLP_API_KEY
+        it.buildConfigField 'String', 'GOOGLE_TRANSLATE_API_KEY', GOOGLE_TRANSLATE_API_KEY
+    }
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
     buildTypes {
         release {
@@ -35,7 +36,7 @@ dependencies {
     compile 'com.google.firebase:firebase-core:9.4.0'
     compile 'com.squareup.okhttp3:okhttp:3.4.1'
     compile 'com.google.firebase:firebase-database:9.4.0'
-    compile project(':volley')
+    compile 'com.android.volley:volley:1.0.0'
     testCompile 'junit:junit:4.12'
 }
 

--- a/app/src/main/java/io/eschmann/dixitapp/MainActivity.java
+++ b/app/src/main/java/io/eschmann/dixitapp/MainActivity.java
@@ -77,6 +77,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     protected TextView userName;
     protected TextView userEmail;
 
+    protected String GOOGLE_NLP_API_KEY = BuildConfig.GOOGLE_NLP_API_KEY;
+    protected String GOOGLE_TRANSLATE_API_KEY = BuildConfig.GOOGLE_TRANSLATE_API_KEY;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -240,7 +243,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             mainListAdapter.notifyDataSetChanged();
             tempp = result;
 
-            String translateUrl = "https://www.googleapis.com/language/translate/v2?key=AIzaSyDdhuqdk-d3KCIH-S09iK7LGGjQQpN1klY&q=" + result + "&source=sv&target=en";
+            String translateUrl = "https://www.googleapis.com/language/translate/v2?key=" + GOOGLE_TRANSLATE_API_KEY + "&q=" + result + "&source=sv&target=en";
             JsonObjectRequest translatePhrase = new JsonObjectRequest(
                     Request.Method.GET, translateUrl, null, new Response.Listener<JSONObject>() {
 
@@ -339,7 +342,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             e.printStackTrace();
         }
 
-        String syntaxUrl = "https://language.googleapis.com/v1beta1/documents:annotateText?key=AIzaSyB4pa0J8WSkLwbGJE3xcXCmmY0NmxPYRlg";
+        String syntaxUrl = "https://language.googleapis.com/v1beta1/documents:annotateText?key=" + GOOGLE_NLP_API_KEY;
         JsonObjectRequest getSyntax = new JsonObjectRequest
             (Request.Method.POST, syntaxUrl, myBody, new Response.Listener<JSONObject>() {
                 @Override

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-rc2'
+        classpath 'com.android.tools.build:gradle:2.2.0'
         classpath 'com.google.gms:google-services:3.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,7 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# API Keys
+GOOGLE_NLP_API_KEY="MY_API_KEY"
+GOOGLE_TRANSLATE_API_KEY="MY_API_KEY"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':app', ':volley'
+include ':app'


### PR DESCRIPTION
- Remove Volley module. Now it's imported as a regular dependency.
- The API keys can now be inserted in gradle.properties and are then imported in the MainActivity
- Update few other files as requested from AndroidStudio
